### PR TITLE
Simplify by removing unnecessary resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ No requirements.
 | comment | Default comment to add to all resources. | `string` | `"Managed by Terraform"` | no |
 | delegation\_sets | A set of four authoritative name servers that you can use with more than one hosted zone. By default, Route 53 assigns a random selection of name servers to each new hosted zone. To make it easier to migrate DNS service to Route 53 for a large number of domains, you can create a reusable delegation set and then associate the reusable delegation set with new hosted zones. | `list(string)` | `[]` | no |
 | public\_root\_zones | Route53 root zone (also allows subdomain if this is your root starting point). Set delegation\_set to 'null' to use no delegation set. | <pre>list(object({<br>    name           = string,<br>    delegation_set = string,<br>  }))</pre> | `[]` | no |
-| public\_subdomain\_zones | Route53 subdomain zone (root zone must be specified as well). Set delegation\_set to 'null' to use no delegation set. | <pre>list(object({<br>    name           = string,<br>    root           = string,<br>    ns_ttl         = number,<br>    nameservers    = list(string),<br>    delegation_set = string,<br>  }))</pre> | `[]` | no |
+| public\_secondary\_zones | Route53 secondary zone ('parent' zone must be specified as well). Set delegation\_set to 'null' to use no delegation set. Use empty 'ns\_servers' list to use AWS default nameserver. | <pre>list(object({<br>    name           = string,<br>    parent         = string,<br>    ns_ttl         = number,<br>    ns_servers     = list(string),<br>    delegation_set = string,<br>  }))</pre> | `[]` | no |
 | tags | Default tags to additionally apply to all resources. | `map` | `{}` | no |
 
 ## Outputs
@@ -97,9 +97,8 @@ No requirements.
 |------|-------------|
 | delegation\_sets | Created delegation sets. |
 | public\_root\_zones | Created public root zones. |
-| public\_subdomain\_custom\_ns\_records | Created public subdomain default ns records. |
-| public\_subdomain\_default\_ns\_records | Created public subdomain default ns records. |
-| public\_subdomain\_zones | Created public subdomain zones. |
+| public\_secondary\_ns\_records | Created public secondary ns records. |
+| public\_secondary\_zones | Created public secondary zones. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/public-subdomains/main.tf
+++ b/examples/public-subdomains/main.tf
@@ -26,19 +26,19 @@ module "aws_route53zone" {
 
   # If delegation set is null, it will use AWS defaults.
   # Specify your own nameserver or use an empty list to use AWS defaults.
-  public_subdomain_zones = [
+  public_secondary_zones = [
     {
       name           = "internal.example.org",
-      root           = "example.org",
+      parent         = "example.org",
       ns_ttl         = 30,
-      nameservers    = [],
+      ns_servers     = [],
       delegation_set = null,
     },
     {
       name           = "private.example.org",
-      root           = "example.org",
+      parent         = "example.org",
       ns_ttl         = 30,
-      nameservers    = ["1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"],
+      ns_servers     = ["1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"],
       delegation_set = null,
     },
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,34 +26,24 @@ output "public_root_zones" {
 
 
 # -------------------------------------------------------------------------------------------------
-# Route53 Public Subdomain Zones
+# Route53 Public Subdomain Zones (secondary)
 # -------------------------------------------------------------------------------------------------
-#output "local_public_subdomain_zones" {
-#  value       = local.public_subdomain_zones
-#  description = "Transformed public subdomain zones."
+#output "local_public_secondary_zones" {
+#  value       = local.public_secondary_zones
+#  description = "Transformed public secondary zones."
 #}
 
-#output "local_public_subdomain_default_ns_records" {
-#  value       = local.public_subdomain_default_ns_records
-#  description = "Transformed public subdomain default ns records."
+#output "local_public_secondary_ns_records" {
+#  value       = local.public_secondary_ns_records
+#  description = "Transformed public secondary ns records."
 #}
 
-#output "local_public_subdomain_custom_ns_records" {
-#  value       = local.public_subdomain_custom_ns_records
-#  description = "Transformed public subdomain custom ns records."
-#}
-
-output "public_subdomain_zones" {
-  value       = aws_route53_zone.public_subdomain_zones
-  description = "Created public subdomain zones."
+output "public_secondary_zones" {
+  value       = aws_route53_zone.public_secondary_zones
+  description = "Created public secondary zones."
 }
 
-output "public_subdomain_default_ns_records" {
-  value       = aws_route53_record.public_subdomain_default_ns_records
-  description = "Created public subdomain default ns records."
-}
-
-output "public_subdomain_custom_ns_records" {
-  value       = aws_route53_record.public_subdomain_custom_ns_records
-  description = "Created public subdomain default ns records."
+output "public_secondary_ns_records" {
+  value       = aws_route53_record.public_secondary_ns_records
+  description = "Created public secondary ns records."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,16 +16,16 @@ variable "public_root_zones" {
   description = "Route53 root zone (also allows subdomain if this is your root starting point). Set delegation_set to 'null' to use no delegation set."
 }
 
-variable "public_subdomain_zones" {
+variable "public_secondary_zones" {
   type = list(object({
     name           = string,
-    root           = string,
+    parent         = string,
     ns_ttl         = number,
-    nameservers    = list(string),
+    ns_servers     = list(string),
     delegation_set = string,
   }))
   default     = []
-  description = "Route53 subdomain zone (root zone must be specified as well). Set delegation_set to 'null' to use no delegation set."
+  description = "Route53 secondary zone ('parent' zone must be specified as well). Set delegation_set to 'null' to use no delegation set. Use empty 'ns_servers' list to use AWS default nameserver."
 }
 
 variable "tags" {


### PR DESCRIPTION
# Simplify by removing unnecessary resources

This PR does two things:

### 1. Simplify

It removes duplicate resources for NS record creation by combining custom and default NS records in a single resource (logic is now in locals)


### 2. Ability to have more sub zones

It renames `subdomain` into `secondary` for two reasons:

1. subdomain is misleading, as we can also make a subdomain a root zone
2. using secondary also allows to extend this module with tertiary, quaternary, quinary, etc if needed without having to use `subsubsubdomain`