### PR TITLE
Release v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ terraform import 'aws_route53_zone.public_root_zones["www.example.com"]' <ZONE-I
 terraform import 'aws_route53_zone.private_root_zones["private.example.com"]' <ZONE-ID>
 ```
 
+### Secondary zones
+Secondary zones will create NS records in their parent zone. So in order to import them, you will
+first have to identify the currently existing NS record in the parent zone, import it
+and then import the secondary zone.
+```bash
+# List records in parent zone
+aws route53 list-resource-record-sets --hosted-zone-id <PARENT-ZONE-ID>
+
+# Import NS record (from parent zone)
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#import
+terraform import 'aws_route53_record.public_delegated_secondary_ns_records["sub.www.example.com"]' <PARENT-ZONE-ID>_sub.www.example.com_NS
+
+# Import Sub zone
+terraform import 'aws_route53_zone.public_delegated_secondary_zones["sub.www.example.com"]' <ZONE-ID>
+```
+
 
 ## Examples
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "aws_route53_record" "public_delegated_secondary_ns_records" {
   name    = each.value.name
   type    = "NS"
   ttl     = each.value.ns_ttl
-  records = each.value.ns_list
+  records = formatlist("%s.", each.value.ns_list)
 
   depends_on = [aws_route53_zone.public_delegated_secondary_zones]
 }


### PR DESCRIPTION
# Release v1.1.2


Currently the module is not adding the trailing `.` (dot) to NS records and will screw up existing DNS NS records for zone delegations. Currently broken behaviour shown below:

```
  # aws_route53_record.public_delegated_secondary_ns_records["www.example.com"] will be updated in-place
  ~ resource "aws_route53_record" "public_delegated_secondary_ns_records" {
        fqdn    = "www.example.com"
        id      = "XXXXXXXXXXXXX_www.example.com_NS"
        name    = "www.example.com"
      ~ records = [
          + "ns-xxxx.awsdns-44.org",
          - "ns-xxxx.awsdns-44.org.",
          + "ns-yyyy.awsdns-57.co.uk",
          - "ns-yyyy.awsdns-57.co.uk.",
          + "ns-zzzz.awsdns-37.com",
          - "ns-zzzz.awsdns-37.com.",
          + "ns-aaaa.awsdns-45.net",
          - "ns-aaaa.awsdns-45.net.",
        ]
        ttl     = 300
        type    = "NS"
        zone_id = "XXXXXXXXXXXXX"
    }
```

## Changes

### Fixed
* Adding trailing dot to NS records
#### Added
* Adds documentatoin about importing secondary delegated zones into TF state